### PR TITLE
Add Python 3.7 compatibility

### DIFF
--- a/tzen/tz_fixture.py
+++ b/tzen/tz_fixture.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Mapping, List
+from typing import Mapping, List, Type
 from enum import Enum
 from dataclasses import dataclass
 from .tz_logging import TZFixtureLogger
@@ -14,7 +14,7 @@ class TZFixtureScope(Enum):
 @dataclass
 class TZFixtureMarker():
     """Dataclass to represent a fixtures marker for objects."""
-    cls: type[TZFixture]
+    cls: Type[TZFixture]
     obj: object = None # Instance of the fixture, will be set when the fixture is used
     args: List[object] = None
     kwargs: Mapping[str, object] = None
@@ -44,7 +44,12 @@ class TZFixtureMarker():
     def __hash__(self):
         return hash((self.cls, tuple(self.args), frozenset(self.kwargs.items()), self.scope))
     
-def tz_use_fixture(fixture_class: type[TZFixture], *args, scope: TZFixtureScope = TZFixtureScope.TEST, **kwargs) -> TZFixture:
+def tz_use_fixture(
+    fixture_class: Type[TZFixture],
+    *args,
+    scope: TZFixtureScope = TZFixtureScope.TEST,
+    **kwargs
+) -> TZFixture:
     """Use a fixture class to create an instance of it."""
     if not issubclass(fixture_class, TZFixture):
         raise TypeError("fixture_class must be a subclass of TZFixture")

--- a/tzen/tz_test_organizer.py
+++ b/tzen/tz_test_organizer.py
@@ -1,3 +1,4 @@
+from typing import List, Union
 from .tz_test import TZTest, tz_get_test_table
 
 class TZTestOrganizer:
@@ -15,19 +16,19 @@ class TZTestOrganizer:
         """Get the number of tests in the organizer. This method should be implemented by subclasses."""
         raise NotImplementedError("This method should be implemented by subclasses.")
     
-    def get_all_tests(self) -> list[TZTest]:
+    def get_all_tests(self) -> List[TZTest]:
         """Get all tests in the organizer. This method should be implemented by subclasses."""
         raise NotImplementedError("This method should be implemented by subclasses.")
     
-    def from_name_list(self, names: list[str]) -> None:
+    def from_name_list(self, names: List[str]) -> None:
         """Fetch tests by their names. This method should be implemented by subclasses."""
         raise NotImplementedError("This method should be implemented by subclasses.")
     
 class TZTestOrganizerList(TZTestOrganizer):
     """Class to organize tests in a list. It allows to add tests and retrieve them in the order they were added."""
-    def __init__(self, tests: list[TZTest] | list[str] = None):
+    def __init__(self, tests: Union[List[TZTest], List[str]] = None):
         super().__init__()
-        self.tests: list[TZTest] = []
+        self.tests: List[TZTest] = []
 
         # Handle initialization with a list of test classes or names
         if tests and len(tests) > 0:
@@ -56,11 +57,11 @@ class TZTestOrganizerList(TZTestOrganizer):
         """Get the number of tests in the organizer."""
         return len(self.tests)
     
-    def get_all_tests(self) -> list[TZTest]:
+    def get_all_tests(self) -> List[TZTest]:
         """Get all tests in the organizer."""
         return self.tests
     
-    def fetch_from_name_list(self, names):
+    def fetch_from_name_list(self, names: List[str]):
         """Fetch tests by their names. It will populate the tests list with the specified test classes."""
         if not isinstance(names, list):
             raise TypeError("names must be a list of test class names") 

--- a/tzen/tz_utils.py
+++ b/tzen/tz_utils.py
@@ -1,5 +1,6 @@
 import inspect
 from pathlib import Path
+from typing import Tuple
 
 def _tz_get_class_full_path(cls: type) -> Path:
     """Get the full path of a class, including its module."""
@@ -17,6 +18,6 @@ def tz_get_class_full_name(cls: type) -> str:
     """Get the full name of a class, including its module."""    
     return _tz_get_class_full_path(cls).as_uri()
 
-def tz_get_class_full_name_parts(cls: type) -> tuple[str, str]:
+def tz_get_class_full_name_parts(cls: type) -> Tuple[str, str]:
     """Get the full name of a class, including its module and file path."""
     return _tz_get_class_full_path(cls).parts


### PR DESCRIPTION
## Summary
- remove builtin generics and union operator usage
- use typing generics for compatibility with Python 3.7

## Testing
- `pytest -q`
- `python -m compileall -q tzen`


------
https://chatgpt.com/codex/tasks/task_e_684f5933b1bc832d9d916cb7ac29aafb